### PR TITLE
Fix uri bug

### DIFF
--- a/examples/simple/build.gradle
+++ b/examples/simple/build.gradle
@@ -28,7 +28,7 @@ task xslt(type: SaxonXsltTask) {
   // Use URIs, just to show a simple arg
   stylesheet "file://${projectDir}/tools/html5.xsl"
   input "file://${projectDir}/xml/input-1.xml"
-  output "file:///${buildDir}/output-1.xml"
+  output "file://${buildDir}/output-1.xml"
   arg '-u'
   parameters([
     "title": "spoon",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = com.nwalsh.gradle.saxon
-version = 0.10.1
+version = 0.10.2

--- a/src/main/groovy/com/nwalsh/gradle/saxon/SaxonTaskImpl.groovy
+++ b/src/main/groovy/com/nwalsh/gradle/saxon/SaxonTaskImpl.groovy
@@ -212,8 +212,9 @@ class SaxonTaskImpl {
       return input
     }
 
+    URI uri;
     try {
-      URI uri = new URI(input)
+      uri = new URI(input)
       if (uri.isAbsolute()) {
         return uri
       }
@@ -221,7 +222,7 @@ class SaxonTaskImpl {
       uri = null // Irrelevant, but make codenarc happy
     }
 
-    URI uri = theBaseURI.resolve("${input}");
+    uri = theBaseURI.resolve("${input}");
     if (uri.getScheme() == FILE_SCHEME) {
       return new File(uri.getPath())
     }


### PR DESCRIPTION
The declaration for `uri` was out of scope in the catch block. Minor typo in the simple example build script.